### PR TITLE
Add basic monitoring stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Backend Monitoring Setup
+
+This repository contains a simple Express backend. The instructions below show how to monitor it using **Prometheus**, **Grafana**, and **Loki**. All services are orchestrated with **Docker Compose** so you can launch the entire stack with a single command.
+
+## Prerequisites
+
+- [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) installed on your machine.
+
+## Running the stack
+
+1. Clone this repository and navigate into it.
+2. Run:
+
+   ```bash
+   docker compose up -d
+   ```
+
+   This builds the backend image and starts Prometheus, Grafana, Loki, and Promtail alongside it.
+
+3. Access the services:
+
+   - **Backend API**: <http://localhost:4000/api/users>
+   - **Prometheus**: <http://localhost:9090>
+   - **Grafana**: <http://localhost:3000> (default credentials: `admin` / `admin`)
+   - **Loki**: <http://localhost:3100>
+
+4. In Grafana, add Prometheus and Loki as data sources using the above URLs. You can then create dashboards to visualize metrics and logs.
+
+## Configuration files
+
+- `docker-compose.yml` – defines all services.
+- `prometheus.yml` – Prometheus scraping configuration.
+- `promtail-config.yml` – Promtail configuration for forwarding logs to Loki.
+
+## Metrics endpoint
+
+The backend exposes a basic metrics endpoint at `/metrics` which reports process uptime and memory usage. Prometheus is configured to scrape this endpoint every 15 seconds.
+
+```bash
+curl http://localhost:4000/metrics
+```
+
+You can extend `index.js` to provide more detailed metrics or structured logging depending on your requirements.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3.8'
+services:
+  backend:
+    build: .
+    ports:
+      - "4000:4000"
+    environment:
+      - NAME=example
+    depends_on:
+      - prometheus
+      - loki
+
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    command: ["--config.file=/etc/prometheus/prometheus.yml"]
+    ports:
+      - "9090:9090"
+
+  loki:
+    image: grafana/loki:2.9.0
+    command: ["-config.file=/etc/loki/local-config.yaml"]
+    ports:
+      - "3100:3100"
+
+  promtail:
+    image: grafana/promtail:2.9.0
+    volumes:
+      - ./promtail-config.yml:/etc/promtail/config.yml
+      - /var/log:/var/log
+    command: ["-config.file=/etc/promtail/config.yml"]
+    depends_on:
+      - loki
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    depends_on:
+      - prometheus
+      - loki

--- a/index.js
+++ b/index.js
@@ -3,9 +3,18 @@ import dotenv from "dotenv";
 dotenv.config();
 import cors from "cors";
 
+// simple request logger
+const requestLogger = (req, res, next) => {
+    console.log(`${req.method} ${req.url}`);
+    next();
+};
+
 const PORT = 4000;
 const name = process.env.NAME;
 const app = express();
+
+// log all incoming requests
+app.use(requestLogger);
 
 // middleware for cors
 app.use(
@@ -31,4 +40,18 @@ app.get("/api/users", (req, res) => {
         status: true,
         users,
     });
+});
+
+// simple Prometheus metrics endpoint
+app.get("/metrics", (req, res) => {
+    const uptime = process.uptime();
+    const memoryUsage = process.memoryUsage().rss;
+    res.set("Content-Type", "text/plain");
+    res.send(`# HELP node_uptime_seconds Uptime of the process in seconds
+# TYPE node_uptime_seconds gauge
+node_uptime_seconds ${uptime}
+# HELP node_memory_usage_bytes Process memory usage
+# TYPE node_memory_usage_bytes gauge
+node_memory_usage_bytes ${memoryUsage}
+`);
 });

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+scrape_configs:
+  - job_name: 'backend'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['backend:4000']

--- a/promtail-config.yml
+++ b/promtail-config.yml
@@ -1,0 +1,14 @@
+server:
+  http_listen_port: 9080
+positions:
+  filename: /tmp/positions.yaml
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+scrape_configs:
+  - job_name: varlogs
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: varlogs
+          __path__: /var/log/*log


### PR DESCRIPTION
## Summary
- log incoming requests and expose metrics
- document setup with Grafana, Prometheus and Loki
- provide Docker Compose stack for monitoring

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856d1e456b48323ae6685b9cd6f77ee